### PR TITLE
refactor: the page headings

### DIFF
--- a/apps/dariaklover/src/app/components/Heading/Heading.test.tsx
+++ b/apps/dariaklover/src/app/components/Heading/Heading.test.tsx
@@ -26,18 +26,18 @@ describe('<Heading />', () => {
   });
 
   describe('Elements inspection', () => {
-    it('should be the `h2` HTML element by default', () => {
+    it('should be the `h1` HTML element by default', () => {
       render(<Heading>Дарья Кловер</Heading>);
-
-      const h2: HTMLHeadingElement | null = document.querySelector('h2');
-      expect(h2).toBeInTheDocument();
-    });
-
-    it('should be the `h1` HTML element', () => {
-      render(<Heading component="h1">Дарья Кловер</Heading>);
 
       const h1: HTMLHeadingElement | null = document.querySelector('h1');
       expect(h1).toBeInTheDocument();
+    });
+
+    it('should be the `h1` HTML element', () => {
+      render(<Heading component="h2">Дарья Кловер</Heading>);
+
+      const h2: HTMLHeadingElement | null = document.querySelector('h2');
+      expect(h2).toBeInTheDocument();
     });
 
     it('should have the CSS classes from `h5` Typography variant by default', () => {

--- a/apps/dariaklover/src/app/components/Heading/Heading.tsx
+++ b/apps/dariaklover/src/app/components/Heading/Heading.tsx
@@ -25,7 +25,7 @@ export interface HeadingProps {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const Heading = React.forwardRef(function Heading(props: HeadingProps, ref: React.Ref<any>) {
-  const { children, component = 'h2', variant = 'h5', ...other } = props;
+  const { children, component = 'h1', variant = 'h5', ...other } = props;
 
   return (
     <Typography ref={ref} component={component} variant={variant} gutterBottom {...other}>

--- a/apps/dariaklover/src/app/components/References/References.tsx
+++ b/apps/dariaklover/src/app/components/References/References.tsx
@@ -358,7 +358,7 @@ function References(props: ReferencesProps) {
   return (
     <>
       <Heading>{heading}</Heading>
-      <Heading component="h3" variant="h6">
+      <Heading component="h2" variant="h6">
         {references[currentSlideIndex].title}
       </Heading>
       <Swiper

--- a/apps/dariaklover/src/app/pages/About/About.test.tsx
+++ b/apps/dariaklover/src/app/pages/About/About.test.tsx
@@ -28,25 +28,25 @@ describe('<About />', () => {
       expect(title).toBe(aboutMetaData.title);
     });
 
-    it('should have the `h2` HTML element as heading', () => {
+    it('should have the `h1` HTML element as heading', () => {
       render(<About />);
 
-      const h2: HTMLHeadingElement | null = document.querySelector('h2');
-      expect(h2).toBeInTheDocument();
+      const h1: HTMLHeadingElement | null = document.querySelector('h1');
+      expect(h1).toBeInTheDocument();
     });
 
     it('should have the CSS classes from `h5` Typography variant by default', () => {
       render(<About />);
 
-      const h2: HTMLHeadingElement | null = document.querySelector('h2');
-      expect(h2).toHaveClass(typographyClasses.h5);
+      const h1: HTMLHeadingElement | null = document.querySelector('h1');
+      expect(h1).toHaveClass(typographyClasses.h5);
     });
 
     it('should have the right constants', () => {
       render(<About />);
 
-      const h2: HTMLHeadingElement | null = document.querySelector('h2');
-      expect(h2).toHaveTextContent(aboutMetaData.heading);
+      const h1: HTMLHeadingElement | null = document.querySelector('h1');
+      expect(h1).toHaveTextContent(aboutMetaData.heading);
     });
   });
 });

--- a/apps/dariaklover/src/app/pages/Booking/Booking.test.tsx
+++ b/apps/dariaklover/src/app/pages/Booking/Booking.test.tsx
@@ -36,16 +36,16 @@ describe('<Booking />', () => {
       expect(title).toBe(bookingMetaData.title);
     });
 
-    it('should have the `h2` HTML element as heading', () => {
+    it('should have the `h1` HTML element as heading', () => {
       render(
         <BrowserRouter>
           <Booking />
         </BrowserRouter>,
       );
 
-      const h2: HTMLHeadingElement | null = document.querySelector('h2');
-      expect(h2).toBeInTheDocument();
-      expect(h2).toHaveTextContent(bookingMetaData.heading);
+      const h1: HTMLHeadingElement | null = document.querySelector('h1');
+      expect(h1).toBeInTheDocument();
+      expect(h1).toHaveTextContent(bookingMetaData.heading);
     });
   });
 });

--- a/apps/dariaklover/src/app/pages/Faq/Faq.tsx
+++ b/apps/dariaklover/src/app/pages/Faq/Faq.tsx
@@ -82,7 +82,7 @@ function Faq() {
         const { question, answer, id } = faqData;
         return (
           <Box id={id} component="section" key={id} sx={{ marginY: 2 }}>
-            <Typography component="h3" sx={{ fontStyle: 'italic' }}>
+            <Typography component="h2" sx={{ fontStyle: 'italic' }}>
               {indexToNumber(index)}. {question}
             </Typography>
             <Paragraph>{answer}</Paragraph>

--- a/apps/dariaklover/src/app/pages/Main/Main.test.tsx
+++ b/apps/dariaklover/src/app/pages/Main/Main.test.tsx
@@ -29,18 +29,18 @@ describe('<Main />', () => {
       expect(title).toBe(mainMetaData.title);
     });
 
-    it('should have the `h2` HTML element as heading', () => {
+    it('should have the `h1` HTML element as heading', () => {
       render(<Main />);
 
-      const h2: HTMLHeadingElement | null = document.querySelector('h2');
-      expect(h2).toBeInTheDocument();
+      const h1: HTMLHeadingElement | null = document.querySelector('h1');
+      expect(h1).toBeInTheDocument();
     });
 
     it('should have the CSS classes from `h5` Typography variant by default', () => {
       render(<Main />);
 
-      const h2: HTMLHeadingElement | null = document.querySelector('h2');
-      expect(h2).toHaveClass(typographyClasses.h5);
+      const h1: HTMLHeadingElement | null = document.querySelector('h1');
+      expect(h1).toHaveClass(typographyClasses.h5);
     });
 
     it('should have the right `strong` element', () => {


### PR DESCRIPTION
Changes:
- use "h1" as heading element
- adjust heading for the References and FAQ page
- fix broken tests